### PR TITLE
cli: requirements.txt: added python-requests

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,3 +1,3 @@
 prettytable==3.5.0
 pyinstaller==5.6.2
-
+requests==2.28.2


### PR DESCRIPTION
Fixes:
```python
[root@54a1c978fb2e cli]# ./dist/openrepo
Traceback (most recent call last):
  File "main.py", line 20, in <module>
    from openrepo_cli.rest_interface import RestInterface
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "openrepo_cli/rest_interface.py", line 15, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
[427] Failed to execute script 'main' due to unhandled exception!
```