### PR TITLE
openrepo-cli: update pyinstaller version

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,3 +1,3 @@
 prettytable==3.5.0
-pyinstaller==5.6.2
+pyinstaller==5.13.0
 requests==2.28.2


### PR DESCRIPTION
Fixed build issue https://github.com/pyinstaller/pyinstaller/issues/7692

```bash
[root@f2de5b0599bb /]# openrepo
[22] Module object for pyimod02_importers is NULL!
Traceback (most recent call last):
  File "PyInstaller/loader/pyimod02_importers.py", line 22, in <module>
  File "pathlib.py", line 14, in <module>
  File "urllib/parse.py", line 40, in <module>
ModuleNotFoundError: No module named 'ipaddress'
Traceback (most recent call last):
  File "PyInstaller/loader/pyiboot01_bootstrap.py", line 17, in <module>
ModuleNotFoundError: No module named 'pyimod02_importers'
[22] Failed to execute script 'pyiboot01_bootstrap' due to unhandled exception!
[root@f2de5b0599bb /]# pyinstaller --version
5.6.2
```
```bash
[root@4f9795061c01 /]# openrepo
usage: openrepo [-h] [-k KEY] [-s SERVER] [--debug] [--json]
                {list_packages,list_repos,list_signingkeys,package_copy,package_delete,package_detail,package_promote,repo_create,repo_delete,repo_details,upload}
                ...
openrepo: error: the following arguments are required: command
[root@4f9795061c01 /]# pyinstaller --version
5.13.0
```