### PR TITLE
Fix build error introduced after updating the base image to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
       libpq-dev          \
       python3            \
       python3-pip        \
+      python3-venv       \
       nginx
       
 WORKDIR /app
@@ -32,8 +33,10 @@ WORKDIR /app
 
 # Copy the requirements.txt first and install dependencies, so that this can be cached
 COPY web/requirements.txt ./django/requirements.txt
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/createrepo_c /usr/bin/createrepo && \
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+RUN ln -s /usr/bin/createrepo_c /usr/bin/createrepo && \
     pip3 install --no-cache-dir -r django/requirements.txt && \
     mkdir -p /var/lib/openrepo/packages/
 

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,17 +1,17 @@
-Django==4.0.7
-djangorestframework==3.13.1
-django-filter==22.1
-django-widget-tweaks==1.4.12
-gevent==22.10.2
-gunicorn==20.1.0
-Markdown==3.4.1
-psycopg2==2.9.5
-python-apt @ git+https://salsa.debian.org/apt-team/python-apt.git@6145b6484d220685edfd922d364afbf065127efe
-python-dateutil==2.8.2
-python-gnupg==0.5.0
-pytz==2022.2.1
-requests==2.28.1
-rpmfile==1.0.8
-sqlparse==0.4.2
-tzdata==2022.6
-urllib3==1.26.11
+Django==4.2.14
+djangorestframework==3.15.2
+django-filter==24.2
+django-widget-tweaks==1.5.0
+gevent==24.2.1
+gunicorn==22.0.0
+Markdown==3.6
+psycopg2==2.9.9
+python-apt @ git+https://salsa.debian.org/apt-team/python-apt.git@2.8.0
+python-dateutil==2.9.0.post0
+python-gnupg==0.5.2
+pytz==2024.1
+requests==2.32.3
+rpmfile==2.0.0
+sqlparse==0.5.0
+tzdata==2024.1
+urllib3==2.2.2


### PR DESCRIPTION
# Problem
Following the update in #16  of the container base image to Ubuntu 24.04, building of the container image no longer works. 

```
 > [stage-1  5/10] RUN ln -s /usr/bin/python3 /usr/bin/python &&     ln -s /usr/bin/createrepo_c /usr/bin/createrepo &&     pip3 install --no-cache-dir -r django/requirements.txt &&     mkdir -p /var/lib/openrepo/packages/:             
0.485 error: externally-managed-environment                                                                                                                                                                                                 
0.485                                                                                                                                                                                                                                       
0.485 × This environment is externally managed                                                                                                                                                                                              
0.485 ╰─> To install Python packages system-wide, try apt install
0.485     python3-xyz, where xyz is the package you are trying to
0.485     install.
[...]
0.485 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.485 hint: See PEP 668 for the detailed specification.
```

While I don't know for sure what changed, I presume that Ubuntu 24.04 no longer allows, by default, the installation of pip packages system-wide.

A second problem (which is not build-time but runtime), is that, after overpassing the issue above (no matter which approach - see below), is that the Django startup fails, with a dependency error (I did not capture the error, but it's likely related to a Python module mismatch with the Python package that is provided by Ubuntu 24.04)

# Approach
There are two approaches to this:
1. Add the `--break-system-packages` parameter to pip; since we are in a dedicated (openrepo) container image, there should be no downside (no other python programs run system wide). Nonetheless, this is the less elegant approach.
2. Use the `venv` module to create a Python environment for Openrepo

I took the second approach in this PR.

For the second issue described in the above, I've updated the `requirements.txt` to the latest version

# Notes
I've manually tested some of the Openrepo functionalities which seem to work; some automated testing should be considered, to cover regressions, for the future.


