### PR TITLE
GH Actions for automatic build and push image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  push:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKERHUB_USERNAME }}/openrepo
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha            
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Problem
An automated build is missing from openrepo; it is desired for two reasons:
- make sure that the build is still passing following branch changes, before merge
- have access to images built from branches, so developers can easily run tests with the changes from the branches
- streamlined release process (creating a release/tag automatically builds the image and pushes it to docker hub)

# Approach
Create a Github workflow using Docker provided actions to [compute the tags](https://github.com/docker/metadata-action), based on branch names and releases, [run the build and push](https://github.com/docker/build-push-action) to Docker Hub.

A mapping of how the image tags are generated based on git tags and branches can be found [here](https://github.com/docker/metadata-action?tab=readme-ov-file#semver).

The workflow will run for all events (push, tags) except `pull_request`.

❗ In order for the Docker Hub push to work, the following must be defined in the repo:
- A repository (⚠️ not environment) variable: `DOCKERHUB_USERNAME`. User for both login to Docker Hub and registry name for tagging
- A secret: `DOCKERHUB_TOKEN` - a token generated from Docker Hub with read/write access to the target Hub repository. Used for retrieving info about the registry (by the `docker/metadata-action` action and for pushing the built image - by `docker/build-push-action`


The image for this PR is `ionnistor/openrepo:inistor-patch-docker-build`
