### PR TITLE
Healthchecks to ensure django container kicks off only after db container is healthy.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   nginx:
     image: openkilt/openrepo:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     volumes:
       - ./openrepo-data:/var/lib/openrepo
 
-
-
   django:
     image: openkilt/openrepo:latest
     expose:
@@ -28,8 +26,8 @@ services:
       - OPENREPO_PG_PASSWORD=postgres
       - OPENREPO_PG_HOSTNAME=db
     depends_on:
-      - "db"
-
+      db:
+        condition: service_healthy
 
   worker:
     image: openkilt/openrepo:latest
@@ -46,7 +44,6 @@ services:
     depends_on:
       - "django"
 
-
   db:
     image: postgres:16.3-alpine3.20
     expose:
@@ -58,3 +55,8 @@ services:
       - POSTGRES_DB=openrepo
     volumes:
       - ./openrepo-data/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "sh -c 'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}'" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
Prior to this proposed fix, django container kicks off as soon as the db container is created. This ends up in these errors on the django container startup as shown in the attached file. 

[all_containers_launch.log](https://github.com/user-attachments/files/16589464/all_containers_launch.log)

The proposed fix implements a health check that uses pg_isready to establish that postgres db is indeed ready, and for the django container to wait for db container to be healthy before kicking off migrations. 