### PR TITLE
Add OPENREPO_CSRF_TRUSTED_ORIGINS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       - ./openrepo-data:/var/lib/openrepo
     environment:
+      # - "OPENREPO_CSRF_TRUSTED_ORIGINS=myproxiedname.example.com"   #Multiple domains are space delimited"
       - OPENREPO_DB_TYPE=postgresql
       - OPENREPO_PG_DATABASE=openrepo
       - OPENREPO_PG_USERNAME=postgres

--- a/web/openrepo/settings.py
+++ b/web/openrepo/settings.py
@@ -59,6 +59,9 @@ else:
     # https://security.stackexchange.com/questions/45687/what-does-djangos-allowed-hosts-variable-actually-do
     ALLOWED_HOSTS = ['*']
 
+    # Added CSRF support through a reverse proxy with different hostname. https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
+    CSRF_TRUSTED_ORIGINS = os.getenv(OPENREPO_CSRF_TRUSTED_ORIGINS,[])
+
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Application definition

--- a/web/openrepo/settings.py
+++ b/web/openrepo/settings.py
@@ -60,7 +60,10 @@ else:
     ALLOWED_HOSTS = ['*']
 
     # Added CSRF support through a reverse proxy with different hostname. https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
-    CSRF_TRUSTED_ORIGINS = os.getenv("OPENREPO_CSRF_TRUSTED_ORIGINS",[])
+if os.getenv("OPENREPO_CSRF_TRUSTED_ORIGINS") :
+    CSRF_TRUSTED_ORIGINS = os.getenv("OPENREPO_CSRF_TRUSTED_ORIGINS").split(' ')
+else:
+    CSRF_TRUSTED_ORIGINS = []
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 

--- a/web/openrepo/settings.py
+++ b/web/openrepo/settings.py
@@ -59,7 +59,8 @@ else:
     # https://security.stackexchange.com/questions/45687/what-does-djangos-allowed-hosts-variable-actually-do
     ALLOWED_HOSTS = ['*']
 
-    # Added CSRF support through a reverse proxy with different hostname. https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
+# Added CSRF support through a reverse proxy with different hostname. https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
+# Origins are space delimited
 if os.getenv("OPENREPO_CSRF_TRUSTED_ORIGINS") :
     CSRF_TRUSTED_ORIGINS = os.getenv("OPENREPO_CSRF_TRUSTED_ORIGINS").split(' ')
 else:

--- a/web/openrepo/settings.py
+++ b/web/openrepo/settings.py
@@ -59,8 +59,8 @@ else:
     # https://security.stackexchange.com/questions/45687/what-does-djangos-allowed-hosts-variable-actually-do
     ALLOWED_HOSTS = ['*']
 
-    # Added CSRF support through a reverse proxy with different hostname. https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
-    CSRF_TRUSTED_ORIGINS = os.getenv(OPENREPO_CSRF_TRUSTED_ORIGINS,[])
+    # Added CSRF support through a reverse proxy with different hostname. https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
+    CSRF_TRUSTED_ORIGINS = os.getenv("OPENREPO_CSRF_TRUSTED_ORIGINS",[])
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 


### PR DESCRIPTION
This adds  CSRF_TRUSTED_ORIGINS to django settiings.py 
configured by  OPENREPO_CSRF_TRUSTED_ORIGINS. Space delimited for multiple origins.

Fix for issue #18 